### PR TITLE
Add Docker support for local development

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+node_modules

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,35 @@
+FROM node:latest
+LABEL authors="Wembley"
+# set our node environment, either development or production
+# defaults to production, compose overrides this to development on build and run
+ARG NODE_ENV=development
+ENV NODE_ENV $NODE_ENV
+
+# default to port 19006 for node, and 19001 and 19002 (tests) for debug
+ARG PORT=19006
+ENV PORT $PORT
+EXPOSE $PORT 19001 19002
+
+# install global packages
+ENV NPM_CONFIG_PREFIX=/home/node/.npm-global
+ENV PATH /home/node/.npm-global/bin:$PATH
+#RUN npm install --unsafe-perm --allow-root -g npm@9.x expo-cli@latest
+
+RUN npm i --unsafe-perm --allow-root -g npm@latest expo-cli@latest
+
+# install dependencies first, in a different location for easier app bind mounting for local development
+# due to default /opt permissions we have to create the dir with root and change perms
+RUN mkdir /opt/react_native_app
+WORKDIR /opt/react_native_app
+ENV PATH /opt/react_native_app/.bin:$PATH
+COPY ./package*.json ./
+RUN npm install
+RUN npm install typescript@latest
+
+# copy in our source code last, as it changes the most
+WORKDIR /opt/react_native_app/app
+# for development, we bind mount volumes; comment out for production
+COPY ./ .
+
+ENTRYPOINT ["npm", "run"]
+CMD ["web"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,12 @@
+services:
+  app:
+    #image: gg-marketing-tool-backend-app
+    build: .
+    ports:
+      - "19000:19000"
+    volumes:
+      - .:/usr/src/app
+      - /usr/src/app/node_modules
+    environment:
+      NODE_ENV: development
+    command: npm run start

--- a/services/index.ts
+++ b/services/index.ts
@@ -1,6 +1,6 @@
 import axios from 'axios';
-// const url = "https://ebusinesscardservices.com"
-const url = "http://localhost:7020"
+const url = "https://www.agoodbusinesscard.icu/api"
+// const url = "http://localhost:7020"
 const services = {
     // getUser: async () => {
     //   //local


### PR DESCRIPTION
This commit introduces `docker-compose.yml`, a `Dockerfile`, and a `.dockerignore` to streamline the local development environment. It also updates the API URL in `services/index.ts` to use the production endpoint.