### PR TITLE
Adjust Docker configuration for new ports and directory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,15 +19,15 @@ RUN npm i --unsafe-perm --allow-root -g npm@latest expo-cli@latest
 
 # install dependencies first, in a different location for easier app bind mounting for local development
 # due to default /opt permissions we have to create the dir with root and change perms
-RUN mkdir /opt/react_native_app
-WORKDIR /opt/react_native_app
-ENV PATH /opt/react_native_app/.bin:$PATH
+RUN mkdir /usr/src/app
+WORKDIR /usr/src/app
+ENV PATH /usr/src/.bin:$PATH
 COPY ./package*.json ./
 RUN npm install
 RUN npm install typescript@latest
 
 # copy in our source code last, as it changes the most
-WORKDIR /opt/react_native_app/app
+#WORKDIR /usr/src/app
 # for development, we bind mount volumes; comment out for production
 COPY ./ .
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,10 +4,14 @@ services:
     build: .
     ports:
       - "19006:19006"
+      - "19001:19001"
+      - "19002:19002"
+      - "19000:19000"
     volumes:
       - .:/usr/src/app
       - /usr/src/app/node_modules
     environment:
       NODE_ENV: development
+    #working_dir: /usr/src/app
     entrypoint: ["npm", "run"]
     command: ["web"]


### PR DESCRIPTION
Updated `docker-compose.yml` to expose new ports `19001`, `19002`, and `19000`. Modified Dockerfile to use `/usr/src/app` directory instead of `/opt/react_native_app`, aligning with standard container structure and simplifying volume management.